### PR TITLE
Revamp profile README with featured projects and stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,95 @@
 <div align="center">
 
-# Pranav | Software Dev
+# Hi, I'm Pranav
 
-I'm Pranav. I like to build stuff that I think is cool! Most of my projects are open source btw.
+### Final-year CS student in Chennai, India — I build developer tools, native apps & AI-powered web apps
 
 <br>
 
 <img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZTNtb2cxdW5vcGNzZXljeDRyMjdvaW55c2xicXBudWYwNDFtenBhbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/SfXCSWdTzkZxFaEnUR/giphy.gif" width="600" alt="Animated Banner">
 
 <br>
+<br>
+
+<a href="https://pranavd.vercel.app">
+  <img src="https://img.shields.io/badge/Portfolio-Website-000?style=for-the-badge&logo=vercel&logoColor=white" alt="Portfolio">
+</a>
+<a href="https://github.com/pranav-dp?tab=repositories">
+  <img src="https://img.shields.io/badge/Projects-Open%20Source-2ea44f?style=for-the-badge&logo=github&logoColor=white" alt="Projects">
+</a>
+
+</div>
+
+---
+
+## About me
+
+- Final-year Computer Science student based in Chennai, India
+- I build things I'd actually use — a menu-bar timer, a prompt-enhancer extension, a campus food-delivery app
+- Currently going deeper into **Go** and developer tooling / CLIs
+- Most of my work is open source — pull it apart, open an issue, send a PR
+- More at **[pranavd.vercel.app](https://pranavd.vercel.app)**
+
+---
+
+## Tech I work with
+
+![Swift](https://img.shields.io/badge/Swift-F05138?style=for-the-badge&logo=swift&logoColor=white)
+![SwiftUI](https://img.shields.io/badge/SwiftUI-0071e3?style=for-the-badge&logo=swift&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
+![Go](https://img.shields.io/badge/Go_(learning)-00ADD8?style=for-the-badge&logo=go&logoColor=white)
+<br>
+![React Native](https://img.shields.io/badge/React_Native-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
+![Expo](https://img.shields.io/badge/Expo-1B1F23?style=for-the-badge&logo=expo&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=next.js&logoColor=white)
+![Firebase](https://img.shields.io/badge/Firebase-FFCA28?style=for-the-badge&logo=firebase&logoColor=black)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
+
+---
+
+## Featured Projects
+
+### [Endurance](https://github.com/pranav-dp/endurance) &nbsp;·&nbsp; `Swift` `SwiftUI`
+A free, open-source **menu-bar productivity app for macOS** — built because paid timers wanted ₹1999/yr for the basics. Native menu-bar Pomodoro, custom presets, session-tracking charts, a global hotkey, and a glassmorphism UI that adapts to dark/light mode. Ships as a downloadable `.dmg`.
+
+[![Download](https://img.shields.io/badge/Download-.dmg-F05138?style=flat-square)](https://github.com/pranav-dp/endurance/releases/latest) &nbsp; [![Repo](https://img.shields.io/badge/Source-Code-181717?style=flat-square&logo=github)](https://github.com/pranav-dp/endurance)
+
+### [ChatGPT Conversation Visualizer](https://github.com/pranav-dp/chatgpt) &nbsp;·&nbsp; `Next.js` `Gemini API`
+A web app that turns your exported **ChatGPT history into an interactive graph** — semantic clustering with AI embeddings, auto-generated topic labels, a timeline view, usage analytics, and CSV/JSON/HTML export. Runs server-side with your own API key, so your data stays yours.
+
+[![Live Demo](https://img.shields.io/badge/Live-gptviewer.vercel.app-000000?style=flat-square&logo=vercel)](https://gptviewer.vercel.app) &nbsp; [![Video](https://img.shields.io/badge/Demo-YouTube-FF0000?style=flat-square&logo=youtube)](https://www.youtube.com/watch?v=VRwfuni9jg0) &nbsp; [![Repo](https://img.shields.io/badge/Source-Code-181717?style=flat-square&logo=github)](https://github.com/pranav-dp/chatgpt)
+
+### [Prompt Enhancer](https://github.com/pranav-dp/prompt-enhancer) &nbsp;·&nbsp; `Chrome Extension` `JS`
+A Chrome extension that **improves your AI prompts on any website** — ChatGPT, Claude, Gemini, Perplexity, anywhere. Multi-provider (OpenAI / Gemini / Anthropic), a `Cmd+Shift+P` shortcut, and API keys stored locally in Chrome sync storage.
+
+[![Repo](https://img.shields.io/badge/Source-Code-181717?style=flat-square&logo=github)](https://github.com/pranav-dp/prompt-enhancer)
+
+### [Customer App](https://github.com/pranav-dp/customerapp) &nbsp;·&nbsp; `React Native` `Expo` `Firebase`
+A **campus food-delivery app** ("a college DoorDash") that actually takes orders. Real-time order tracking, Razorpay payments, bill-splitting, a group "Treat Mode," order scheduling, push notifications, and reviews — cross-platform on iOS, Android & web from one TypeScript codebase.
+
+[![Repo](https://img.shields.io/badge/Source-Code-181717?style=flat-square&logo=github)](https://github.com/pranav-dp/customerapp)
+
+---
+
+## GitHub Stats
+
+<div align="center">
+
+<img height="165" src="https://github-readme-stats.vercel.app/api?username=pranav-dp&show_icons=true&theme=tokyonight&hide_border=true&count_private=true&include_all_commits=true" alt="Pranav's GitHub stats" />
+<img height="165" src="https://github-readme-stats.vercel.app/api/top-langs/?username=pranav-dp&layout=compact&theme=tokyonight&hide_border=true&langs_count=8" alt="Top languages" />
+
+</div>
+
+---
+
+<div align="center">
 
 <img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzRzNmdjNTI0eDlkMzlrN214eDF3anhzMTJkZWJsY24xNG5vbWtjdyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/0mSbmyxpgBhNfliH1p/giphy.gif" width="200" alt="Footer Banner">
 
 <br>
-<hr>
+
+**Thanks for stopping by — most of my stuff is open source, so dig in.**
 
 <a href="https://pranavd.vercel.app">
   <img src="https://img.shields.io/badge/Portfolio-Website-000?style=for-the-badge&logo=vercel&logoColor=white" alt="Portfolio">


### PR DESCRIPTION
## What this does

Upgrades the profile landing page (`pranav-dp/pranav-dp/README.md`) from a minimal banner into a proper showcase.

### Changes
- **About section** — who I am (final-year CS student, Chennai) and what I build
- **Tech badges** — Swift/SwiftUI, TypeScript, JavaScript, React Native/Expo, Next.js, Firebase, Tailwind, Go (learning)
- **Four featured project cards** with one-line descriptions, tech tags, and action links:
  - **Endurance** — macOS menu-bar productivity app (Swift/SwiftUI) + .dmg download
  - **ChatGPT Conversation Visualizer** — Next.js + Gemini graph viewer + live demo & YouTube
  - **Prompt Enhancer** — multi-provider Chrome extension
  - **Customer App** — React Native + Expo + Firebase campus food-delivery app
- **GitHub stats** — stats card + top-languages card (TokyoNight theme)

### Preserved
- Both existing banner/footer GIFs
- Portfolio link (pranavd.vercel.app)
- The `pranav.gif` asset (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new sections: "About me", "Tech I work with", and "Featured Projects"
  * Added GitHub stats visualization
  * Refreshed overall profile structure and messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->